### PR TITLE
Save search if no album tagged

### DIFF
--- a/src/components/search/SearchResultItem.jsx
+++ b/src/components/search/SearchResultItem.jsx
@@ -6,7 +6,7 @@ import { getIconFromURI } from "utils/uris";
 const SearchResultItem = ({ track, onClick }) => {
   const artistAndAlbum = (
     <span>
-      <ArtistSentence artists={track.artists} /> - {track.album.name}
+      <ArtistSentence artists={track.artists} /> - {track.album?.name ?? "Unknown Album"}
     </span>
   );
 


### PR DESCRIPTION
The frontend always crashed if there was no album tag in the mp3 file.
