### PR TITLE
Fix search crash caused by react-spinners CJS interop bug

### DIFF
--- a/src/components/search/Search.jsx
+++ b/src/components/search/Search.jsx
@@ -5,7 +5,7 @@ import { Transition } from "react-transition-group";
 import { searchLibrary, queueTrack, playIfStopped } from "services/mopidy.js";
 import { useLocation } from "wouter";
 import toast from "react-hot-toast";
-import BounceLoader from "react-spinners/BounceLoader";
+import { BounceLoader } from "react-spinners";
 import CloseIcon from "@mui/icons-material/Close";
 import { useDebounce } from "hooks/debounce.js";
 import { IconButton } from "@mui/material";
@@ -104,7 +104,9 @@ const Search = () => {
   } else if (error) {
     displayResults = (
       <div className="max-w-4xl mx-auto">
-        <h4 className="text-center text-white m-2">{error}</h4>
+        <h4 className="text-center text-white m-2">
+          {error?.message ?? String(error)}
+        </h4>
       </div>
     );
   } else if (results && !results.length) {


### PR DESCRIPTION
This was generated by claude, as far as I can tell its sensible and it did fix it on my machine, but I have no good grasp of what these changes might affect on other systems.

Fixes #55. Searching in the Pibox web UI crashed to a blank white screen
with "Minified React error #130" the instant a search was triggered,
regardless of backend (local, Spotify, or both).

Root cause: `Search.jsx` imports `BounceLoader` via a default import from a
deep subpath (`react-spinners/BounceLoader`). Vite 8.1.0's Rolldown bundler's
CJS→ESM interop helper (`__toESM`) is invoked for this specific import with
an `isNodeMode=1` flag, which forces the entire CJS module object to be used
as `.default` — even though the module sets `exports.__esModule = true` and
`exports.default = BounceLoader` correctly. So `BounceLoader` in `Search.jsx`
was bound to `{ __esModule: true, default: [Function] }` instead of the
function itself. React only discovers this when it tries to render
`<BounceLoader />`, which happens exactly when a search starts (`fetching`
becomes `true`), throwing "Element type is invalid... but got: object" —
reported as minified error #130 in production.

Full writeup with the debugging trail is in the issue comment on #55.

## Fix

- Import `BounceLoader` as a named export from the package root
  (`import { BounceLoader } from "react-spinners"`) instead of the default
  export from the subpath. The root package's ESM entry re-exports it via a
  pure ESM path that never touches the broken interop branch.
- Minor hardening: the error-display branch was rendering `{error}` directly,
  which would itself crash with the same class of error if `searchLibrary()`
  ever rejected with a real `Error` object. Changed to
  `error?.message ?? String(error)`.
